### PR TITLE
Update landing page screenshots

### DIFF
--- a/landing/src/App.jsx
+++ b/landing/src/App.jsx
@@ -7,19 +7,19 @@ import { Input } from './components/ui/input'
 function App() {
   const screenshots = [
     {
-      src: 'https://via.placeholder.com/600x350?text=Screenshot+1',
+      src: '/images/buy_sell.png',
       caption: 'Buy/Sell Volume Distribution Over Time',
     },
     {
-      src: 'https://via.placeholder.com/600x350?text=Screenshot+2',
+      src: '/images/imbalance.png',
       caption: 'Buyer/Seller Imbalance Zones',
     },
     {
-      src: 'https://via.placeholder.com/600x350?text=Screenshot+3',
+      src: '/images/trade_size.png',
       caption: 'Trade Size Histograms',
     },
     {
-      src: 'https://via.placeholder.com/600x350?text=Screenshot+4',
+      src: '/images/top_traders.png',
       caption: 'Top Buy/Sell Trade Tables',
     },
   ]


### PR DESCRIPTION
## Summary
- load screenshots from `landing/images` instead of placeholders

## Testing
- `npm install --prefix landing`
- `npm run lint --prefix landing`


------
https://chatgpt.com/codex/tasks/task_e_6842e4d2fe9883218ee71fe67f9afe36