### PR TITLE
Make header sticky

### DIFF
--- a/landing/src/components/Nav.jsx
+++ b/landing/src/components/Nav.jsx
@@ -2,7 +2,7 @@ import { Button } from './ui/button'
 
 export default function Nav({ onGetEarlyAccess }) {
   return (
-    <nav className="bg-white shadow">
+    <nav className="bg-white/80 backdrop-blur-md shadow sticky top-0 z-50">
       <div className="container mx-auto px-4 py-4 flex items-center justify-between">
         <span className="text-lg font-semibold text-primary">BigGuys</span>
         <Button onClick={onGetEarlyAccess}>Get Early Access</Button>


### PR DESCRIPTION
## Summary
- make the navbar stay visible by adding sticky classes

## Testing
- `npm run lint --prefix landing`


------
https://chatgpt.com/codex/tasks/task_e_6842f6526d50832199ddc404b4ba7703