### PR TITLE
Add dark mode toggle

### DIFF
--- a/landing/index.html
+++ b/landing/index.html
@@ -13,7 +13,7 @@
     <script src="https://cdn.tailwindcss.com"></script>
     <title>Landing Page</title>
   </head>
-  <body class="font-sans bg-gray-50 text-gray-800">
+  <body class="font-sans bg-gray-50 text-gray-800 dark:bg-gray-900 dark:text-gray-100">
     <div id="root"></div>
     <script type="module" src="/src/main.jsx"></script>
   </body>

--- a/landing/src/App.jsx
+++ b/landing/src/App.jsx
@@ -42,7 +42,7 @@ function App() {
   }
 
   return (
-    <div>
+    <div className="min-h-screen bg-white dark:bg-gray-900">
       <Nav onGetEarlyAccess={scrollToBottom} />
       <header className="text-center py-16 bg-gradient-to-r from-primary to-indigo-600 text-white">
         <Motion.h1
@@ -57,7 +57,7 @@ function App() {
           initial={{ opacity: 0, y: 20 }}
           whileInView={{ opacity: 1, y: 0 }}
           viewport={{ once: true }}
-          className="text-gray-600"
+          className="text-gray-600 dark:text-gray-400"
         >
           Track Big Player Activity in BTC and ETH Markets
         </Motion.p>
@@ -65,7 +65,7 @@ function App() {
           initial={{ opacity: 0, y: 20 }}
           whileInView={{ opacity: 1, y: 0 }}
           viewport={{ once: true }}
-          className="text-gray-600 mt-2"
+          className="text-gray-600 dark:text-gray-400 mt-2"
         >
           Detect real-time buy/sell pressure across multiple timeframes.
           Understand when large traders move.
@@ -86,11 +86,11 @@ function App() {
         className="max-w-3xl mx-auto py-12 px-4"
       >
         <h2 className="text-2xl font-semibold mb-4">What is BigGuys?</h2>
-        <p className="mb-4 text-gray-600">
+        <p className="mb-4 text-gray-600 dark:text-gray-400">
           BigGuys is a smart volume analytics module built for crypto markets. It
           allows you to analyze who’s buying, who’s selling, how much, and when.
         </p>
-        <ul className="list-disc space-y-2 ml-6 text-gray-600">
+        <ul className="list-disc space-y-2 ml-6 text-gray-600 dark:text-gray-400">
           <li>Filter by deal size, pair, timeframe and volume clusters.</li>
           <li>Detect liquidity imbalances and validate open interest.</li>
           <li>Strengthen entry/exit signals with smarter volume strategies.</li>
@@ -114,7 +114,7 @@ function App() {
               src={screenshots[current].src}
               alt={screenshots[current].caption}
             />
-            <p className="text-gray-600 mt-2">
+            <p className="text-gray-600 dark:text-gray-400 mt-2">
               {screenshots[current].caption}
             </p>
           </div>
@@ -131,7 +131,7 @@ function App() {
         className="max-w-3xl mx-auto py-12 px-4"
       >
         <h2 className="text-2xl font-semibold mb-4">Who is it for?</h2>
-        <ul className="list-disc ml-6 space-y-2 text-gray-600">
+        <ul className="list-disc ml-6 space-y-2 text-gray-600 dark:text-gray-400">
           <li>Crypto Traders</li>
           <li>Algo Strategy Developers</li>
           <li>Bot Builders</li>
@@ -146,7 +146,7 @@ function App() {
         className="max-w-3xl mx-auto py-12 px-4"
       >
         <h2 className="text-2xl font-semibold mb-4 text-center">FAQ</h2>
-        <div className="space-y-6 text-gray-600 max-w-3xl mx-auto">
+        <div className="space-y-6 text-gray-600 dark:text-gray-400 max-w-3xl mx-auto">
           <div>
             <h3 className="font-semibold text-lg">What is BigGuys?</h3>
             <p>
@@ -194,7 +194,7 @@ function App() {
         className="max-w-3xl mx-auto py-12 px-4 text-center"
       >
         <h2 className="text-2xl font-semibold mb-4">Be First to Try BigGuys</h2>
-        <p className="mb-4 text-gray-600">
+        <p className="mb-4 text-gray-600 dark:text-gray-400">
           We’re launching a private alpha soon. Enter your email to get early
           access.
         </p>
@@ -213,11 +213,11 @@ function App() {
         </form>
       </Motion.section>
 
-      <footer id="page-end" className="bg-gray-100 text-center py-8 mt-12">
-        <p>
+      <footer id="page-end" className="bg-gray-100 dark:bg-gray-800 text-center py-8 mt-12">
+        <p className="dark:text-gray-400">
           Contact: <a href="mailto:support@flowglow.ai">support@flowglow.ai</a>
         </p>
-        <p className="mt-2">
+        <p className="mt-2 dark:text-gray-400">
           <a href="#" className="text-primary hover:underline">
             Telegram
           </a>{' '}
@@ -230,7 +230,7 @@ function App() {
             LinkedIn
           </a>
         </p>
-        <p className="mt-2">&copy; FlowGlow Analytics, 2025</p>
+        <p className="mt-2 dark:text-gray-400">&copy; FlowGlow Analytics, 2025</p>
       </footer>
     </div>
   )

--- a/landing/src/components/Nav.jsx
+++ b/landing/src/components/Nav.jsx
@@ -1,11 +1,15 @@
 import { Button } from './ui/button'
+import ThemeToggle from './ThemeToggle'
 
 export default function Nav({ onGetEarlyAccess }) {
   return (
-    <nav className="bg-white/80 backdrop-blur-md shadow sticky top-0 z-50">
+    <nav className="bg-white/80 dark:bg-gray-800/80 backdrop-blur-md shadow sticky top-0 z-50">
       <div className="container mx-auto px-4 py-4 flex items-center justify-between">
         <span className="text-lg font-semibold text-primary">BigGuys</span>
-        <Button onClick={onGetEarlyAccess}>Get Early Access</Button>
+        <div className="flex items-center gap-2">
+          <ThemeToggle />
+          <Button onClick={onGetEarlyAccess}>Get Early Access</Button>
+        </div>
       </div>
     </nav>
   )

--- a/landing/src/components/ThemeToggle.jsx
+++ b/landing/src/components/ThemeToggle.jsx
@@ -1,0 +1,30 @@
+import { useEffect, useState } from 'react'
+
+export default function ThemeToggle() {
+  const [theme, setTheme] = useState('light')
+
+  useEffect(() => {
+    const stored = localStorage.getItem('theme')
+    if (stored === 'dark') {
+      setTheme('dark')
+      document.documentElement.classList.add('dark')
+    }
+  }, [])
+
+  const toggle = () => {
+    const next = theme === 'dark' ? 'light' : 'dark'
+    setTheme(next)
+    localStorage.setItem('theme', next)
+    if (next === 'dark') {
+      document.documentElement.classList.add('dark')
+    } else {
+      document.documentElement.classList.remove('dark')
+    }
+  }
+
+  return (
+    <button onClick={toggle} className="text-xl">
+      {theme === 'dark' ? '🌙' : '☀️'}
+    </button>
+  )
+}

--- a/landing/src/components/ui/input.jsx
+++ b/landing/src/components/ui/input.jsx
@@ -5,6 +5,7 @@ export function Input({ className, ...props }) {
     <input
       className={clsx(
         'flex h-10 w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2',
+        'dark:bg-gray-800 dark:border-gray-700 dark:placeholder-gray-400 dark:text-gray-100 dark:focus:ring-offset-gray-950',
         className
       )}
       {...props}

--- a/landing/tailwind.config.js
+++ b/landing/tailwind.config.js
@@ -1,4 +1,5 @@
 export default {
+  darkMode: 'class',
   content: ["./index.html", "./src/**/*.{js,jsx}"],
   safelist: [
     'inline-flex',


### PR DESCRIPTION
## Summary
- enable `darkMode: 'class'` in Tailwind
- add dark classes to HTML body and main layout
- create `ThemeToggle` component and use in `Nav`
- adjust `Input` styles for dark theme
- update sections with dark text colors

## Testing
- `npm run lint --prefix landing`
- `npm run build --prefix landing`


------
https://chatgpt.com/codex/tasks/task_e_6842fe62db848321a007516207f6c827