### PR TITLE
Fix dark mode toggle in landing page

### DIFF
--- a/landing/index.html
+++ b/landing/index.html
@@ -10,6 +10,21 @@
       href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"
       rel="stylesheet"
     />
+    <script>
+      tailwind.config = {
+        darkMode: 'class',
+        theme: {
+          extend: {
+            fontFamily: {
+              sans: ['Inter', 'sans-serif'],
+            },
+            colors: {
+              primary: '#6366f1',
+            },
+          },
+        },
+      }
+    </script>
     <script src="https://cdn.tailwindcss.com"></script>
     <title>Landing Page</title>
   </head>


### PR DESCRIPTION
## Summary
- ensure Tailwind CDN uses `darkMode: 'class'`
- extend CDN config with primary color and Inter font

## Testing
- `npm install`
- `npm run lint --silent`

------
https://chatgpt.com/codex/tasks/task_e_684303eadd608321b2d60e942dc780b0