### PR TITLE
Fix theme toggle

### DIFF
--- a/landing/index.html
+++ b/landing/index.html
@@ -11,6 +11,11 @@
       rel="stylesheet"
     />
     <script>
+      if (localStorage.getItem('theme') === 'dark') {
+        document.documentElement.classList.add('dark')
+      }
+    </script>
+    <script>
       tailwind.config = {
         darkMode: 'class',
         theme: {

--- a/landing/src/components/ThemeToggle.jsx
+++ b/landing/src/components/ThemeToggle.jsx
@@ -1,26 +1,27 @@
 import { useEffect, useState } from 'react'
 
 export default function ThemeToggle() {
-  const [theme, setTheme] = useState('light')
+  const [theme, setTheme] = useState(() => {
+    if (typeof window !== 'undefined') {
+      const stored = localStorage.getItem('theme')
+      if (stored) return stored
+      return document.documentElement.classList.contains('dark')
+        ? 'dark'
+        : 'light'
+    }
+    return 'light'
+  })
 
   useEffect(() => {
-    const stored = localStorage.getItem('theme')
-    if (stored === 'dark') {
-      setTheme('dark')
-      document.documentElement.classList.add('dark')
-    }
-  }, [])
-
-  const toggle = () => {
-    const next = theme === 'dark' ? 'light' : 'dark'
-    setTheme(next)
-    localStorage.setItem('theme', next)
-    if (next === 'dark') {
+    if (theme === 'dark') {
       document.documentElement.classList.add('dark')
     } else {
       document.documentElement.classList.remove('dark')
     }
-  }
+    localStorage.setItem('theme', theme)
+  }, [theme])
+
+  const toggle = () => setTheme(theme === 'dark' ? 'light' : 'dark')
 
   return (
     <button onClick={toggle} className="text-xl">


### PR DESCRIPTION
## Summary
- fix ThemeToggle logic and persistence
- add early script to apply saved theme

## Testing
- `npm run lint --prefix landing`
- `npm run build --prefix landing`

------
https://chatgpt.com/codex/tasks/task_e_6843097432048321853f22a899d57fec