### PR TITLE
Fix dark mode toggle

### DIFF
--- a/landing/index.html
+++ b/landing/index.html
@@ -13,6 +13,7 @@
     <script>
       if (localStorage.getItem('theme') === 'dark') {
         document.documentElement.classList.add('dark')
+        document.body.classList.add('dark')
       }
     </script>
     <script>

--- a/landing/src/components/ThemeToggle.jsx
+++ b/landing/src/components/ThemeToggle.jsx
@@ -15,8 +15,10 @@ export default function ThemeToggle() {
   useEffect(() => {
     if (theme === 'dark') {
       document.documentElement.classList.add('dark')
+      document.body.classList.add('dark')
     } else {
       document.documentElement.classList.remove('dark')
+      document.body.classList.remove('dark')
     }
     localStorage.setItem('theme', theme)
   }, [theme])


### PR DESCRIPTION
## Summary
- ensure the previously stored theme is applied to both the `<html>` and `<body>` elements on page load
- update `ThemeToggle` component so toggling also updates `<body>`

## Testing
- `npm run lint`
- `npm run build`
- `npm run dev` *(launched and terminated to ensure it starts)*

------
https://chatgpt.com/codex/tasks/task_e_68430b2d5d9483218fc6006b0c9f4cc3