### PR TITLE
Integrate vite-plugin-ssg

### DIFF
--- a/landing/package-lock.json
+++ b/landing/package-lock.json
@@ -23,6 +23,7 @@
         "@types/react": "^19.1.2",
         "@types/react-dom": "^19.1.2",
         "@vitejs/plugin-react": "^4.4.1",
+        "@wroud/vite-plugin-ssg": "^5.3.0",
         "eslint": "^9.25.0",
         "eslint-plugin-react-hooks": "^5.2.0",
         "eslint-plugin-react-refresh": "^0.4.19",
@@ -2051,6 +2052,37 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0"
       }
     },
+    "node_modules/@wroud/vite-plugin-asset-resolver": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@wroud/vite-plugin-asset-resolver/-/vite-plugin-asset-resolver-0.3.0.tgz",
+      "integrity": "sha512-OAvo7NuapT7P+4n6ZcPBeF3UD5V41/N+Xd6T+WhYr3W+8ZEVduJUBf5P/68xNV6W27myUuDAdtYD5sTA4IMI7w==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "vp-asset-resolver": "lib/cli.js"
+      },
+      "peerDependencies": {
+        "vite": "*"
+      }
+    },
+    "node_modules/@wroud/vite-plugin-ssg": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@wroud/vite-plugin-ssg/-/vite-plugin-ssg-5.3.0.tgz",
+      "integrity": "sha512-DGuTTJkbUS4zzL9x2I2ovarb6Yj/Mf7GeGPDJFc5le1Z+ezIvwA5wYfttHC2VdO8+Jn4O7amDsD7Q9dgMH/AKQ==",
+      "dev": true,
+      "dependencies": {
+        "@wroud/vite-plugin-asset-resolver": "^0.3.0",
+        "change-case": "^5",
+        "magic-string": "^0",
+        "style-to-object": "^1",
+        "tinyglobby": "^0"
+      },
+      "peerDependencies": {
+        "react": "^19.0.0",
+        "react-dom": "^19.0.0",
+        "vite": "^6.3.0"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.14.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.1.tgz",
@@ -2260,6 +2292,13 @@
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
+    },
+    "node_modules/change-case": {
+      "version": "5.4.4",
+      "resolved": "https://registry.npmjs.org/change-case/-/change-case-5.4.4.tgz",
+      "integrity": "sha512-HRQyTk2/YPEkt9TnUPbOpr64Uw3KOicFWPVBb+xiHvd6eBx/qPr9xqfBFDT8P2vWsvvz4jbEkfDe71W3VyNu2w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/chownr": {
       "version": "3.0.0",
@@ -2879,6 +2918,13 @@
       "engines": {
         "node": ">=0.8.19"
       }
+    },
+    "node_modules/inline-style-parser": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.4.tgz",
+      "integrity": "sha512-0aO8FkhNZlj/ZIbNi7Lxxr12obT7cL1moPfE4tg1LkX7LlLfC6DeX4l2ZEud1ukP9jNQyNnfzQVqwbwmAATY4Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/is-extglob": {
       "version": "2.1.1",
@@ -3767,6 +3813,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/style-to-object": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-1.0.9.tgz",
+      "integrity": "sha512-G4qppLgKu/k6FwRpHiGiKPaPTFcG3g4wNVX/Qsfu+RqQM30E7Tyu/TEgxcL9PNLF5pdRLwQdE3YKKf+KF2Dzlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inline-style-parser": "0.2.4"
       }
     },
     "node_modules/supports-color": {

--- a/landing/package.json
+++ b/landing/package.json
@@ -25,6 +25,7 @@
     "@types/react": "^19.1.2",
     "@types/react-dom": "^19.1.2",
     "@vitejs/plugin-react": "^4.4.1",
+    "@wroud/vite-plugin-ssg": "^5.3.0",
     "eslint": "^9.25.0",
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.19",

--- a/landing/src/Index.jsx
+++ b/landing/src/Index.jsx
@@ -1,0 +1,59 @@
+import {
+  Html,
+  Head,
+  Body,
+  Link,
+  Script,
+} from "@wroud/vite-plugin-ssg/react/components";
+import indexStyles from "./index.css?url";
+import App from "./App.jsx";
+
+export default function Index() {
+  const themeScript = `
+    if (localStorage.getItem('theme') === 'dark') {
+      document.documentElement.classList.add('dark')
+      document.body.classList.add('dark')
+    }
+  `;
+
+  const tailwindConfig = `
+    tailwind.config = {
+      darkMode: 'class',
+      theme: {
+        extend: {
+          colors: {
+            primary: '#6366f1'
+          }
+        }
+      }
+    }
+  `;
+
+  return (
+    <Html lang="en">
+      <Head>
+        <meta charSet="UTF-8" />
+        <Link rel="icon" type="image/svg+xml" href="/favicon.ico" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <Link rel="preconnect" href="https://fonts.googleapis.com" />
+        <Link
+          rel="preconnect"
+          href="https://fonts.gstatic.com"
+          crossOrigin=""
+        />
+        <Link
+          href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"
+          rel="stylesheet"
+        />
+        <Script forceNonce>{themeScript}</Script>
+        <Script src="https://cdn.tailwindcss.com" data-mode="watch" />
+        <Script forceNonce>{tailwindConfig}</Script>
+        <Link rel="stylesheet" href={indexStyles} />
+        <title>FlowGlow Analytics</title>
+      </Head>
+      <Body className="font-sans bg-gray-50 text-gray-800 dark:bg-gray-900 dark:text-gray-100">
+        <App />
+      </Body>
+    </Html>
+  );
+}

--- a/landing/vite.config.js
+++ b/landing/vite.config.js
@@ -1,7 +1,24 @@
-import { defineConfig } from 'vite'
-import react from '@vitejs/plugin-react'
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+import { ssgPlugin } from "@wroud/vite-plugin-ssg";
+import path from "node:path";
 
 // https://vite.dev/config/
 export default defineConfig({
-  plugins: [react()],
-})
+  root: "src",
+  build: {
+    target: "esnext",
+    rollupOptions: {
+      input: {
+        index:
+          path.resolve(
+            path.dirname(new URL(import.meta.url).pathname),
+            "src/Index.jsx",
+          ) + "?ssg-entry",
+      },
+    },
+    outDir: "../dist",
+  },
+  appType: "mpa",
+  plugins: [react(), ssgPlugin()],
+});


### PR DESCRIPTION
## Summary
- add `@wroud/vite-plugin-ssg` dev dependency
- create SSG entry component using plugin helpers
- configure Vite to build with vite-plugin-ssg

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684923a85a848321a464aa5e97dfe2db