### PR TITLE
Fix images by setting Vite publicDir

### DIFF
--- a/landing/vite.config.js
+++ b/landing/vite.config.js
@@ -1,6 +1,5 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
-import { ssgPlugin } from "@wroud/vite-plugin-ssg";
 import { viteStaticCopy } from "vite-plugin-static-copy";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -9,6 +8,7 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 export default defineConfig({
   root: "src",
+  publicDir: path.resolve(__dirname, "public"),
   build: {
     target: "esnext",
     outDir: "../dist",


### PR DESCRIPTION
## Summary
- ensure public assets are served when Vite root is `src`
- clean up unused import

## Testing
- `npm run lint --prefix landing`
- `npm run build --prefix landing`

------
https://chatgpt.com/codex/tasks/task_e_684a86e069408321b36e101f643005d6