### PR TITLE
Fix icon path

### DIFF
--- a/landing/index.html
+++ b/landing/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/favicon.ico" />
+    <link rel="icon" type="image/x-icon" href="/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />

--- a/landing/src/Index.jsx
+++ b/landing/src/Index.jsx
@@ -33,7 +33,7 @@ export default function Index() {
     <Html lang="en">
       <Head>
         <meta charSet="UTF-8" />
-        <Link rel="icon" type="image/svg+xml" href="/favicon.ico" />
+        <Link rel="icon" type="image/x-icon" href="/favicon.ico" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <Link rel="preconnect" href="https://fonts.googleapis.com" />
         <Link

--- a/landing/src/index.html
+++ b/landing/src/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/favicon.ico" />
+    <link rel="icon" type="image/x-icon" href="/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />


### PR DESCRIPTION
## Summary
- correct favicon media type to use the `.ico` file

## Testing
- `npm run lint --prefix landing` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684a8df282b88321b04780e8ae1e4488